### PR TITLE
Sort finalised intervals by block number

### DIFF
--- a/web/src/pages/HomePage.js
+++ b/web/src/pages/HomePage.js
@@ -58,7 +58,9 @@ function FinalizedIntervals() {
       )}
       {snapshots && (
         <Stack spacing={1} direction="column-reverse">
-          {snapshots.map(({ args: [rewardIndex, , , endTime] }) => (
+          {snapshots
+            .sort((a,b) => a.blockNumber - b.blockNumber)
+            .map(({ args: [rewardIndex, , , endTime] }) => (
             <Card key={rewardIndex} elevation={5}>
               <CardActionArea component={Link} to={`/finalized/${rewardIndex}`}>
                 <CardHeader


### PR DESCRIPTION
## Problem
At the moment when selecting an interval the finalised intervals are sorted randomly, which makes finding the one you're interested in difficult.

## Solution
By explicitly sorting the snapshots by the block number we get a more intuitive behaviour.

### Screenshot
![image](https://github.com/dmccartney/rocketbread/assets/6219869/71bcafb1-31fd-410b-b179-1913a8c54412)
