### PR TITLE
Implement value trimming as styled component

### DIFF
--- a/web/src/components/RewardSummary.js
+++ b/web/src/components/RewardSummary.js
@@ -18,11 +18,12 @@ import { ResponsiveContainer, Tooltip, Treemap } from "recharts";
 import deepPurple from "@mui/material/colors/deepPurple";
 import { DataGrid } from "@mui/x-data-grid";
 import WalletChip from "./WalletChip";
-import { BNSortComparator, etherscanUrl, trimValue } from "../utils";
+import { BNSortComparator, etherscanUrl } from "../utils";
 import { useEnsAddress } from "wagmi";
 import moment from "moment/moment";
 import { useSearchParams } from "react-router-dom";
 import IsClaimedIcon from "./IsClaimedIcon";
+import TrimmedCell from "./TrimmedCell";
 
 export default function RewardSummary({ rewards, snapshot = null }) {
   let [pageSize, setPageSize] = useState(10);
@@ -252,9 +253,9 @@ export default function RewardSummary({ rewards, snapshot = null }) {
                 ethers.BigNumber.from(oracleDaoRpl)
               );
             },
-            valueFormatter: ({ value }) => {
-              return trimValue(ethers.utils.formatUnits(value));
-            },
+            renderCell: (params) => (
+              <TrimmedCell value={params.value || 0} />
+            ),
           },
           {
             field: "collateralRpl",
@@ -265,9 +266,9 @@ export default function RewardSummary({ rewards, snapshot = null }) {
             valueGetter: ({ value }) => {
               return ethers.BigNumber.from(value);
             },
-            valueFormatter: ({ value }) => {
-              return trimValue(ethers.utils.formatUnits(value));
-            },
+            renderCell: (params) => (
+              <TrimmedCell value={params.value || 0} />
+            ),
           },
           {
             field: "oracleDaoRpl",
@@ -278,9 +279,9 @@ export default function RewardSummary({ rewards, snapshot = null }) {
             valueGetter: ({ value }) => {
               return ethers.BigNumber.from(value);
             },
-            valueFormatter: ({ value }) => {
-              return trimValue(ethers.utils.formatUnits(value));
-            },
+            renderCell: (params) => (
+              <TrimmedCell value={params.value || 0} />
+            ),
           },
           {
             field: "smoothingPoolEth",
@@ -291,9 +292,9 @@ export default function RewardSummary({ rewards, snapshot = null }) {
             valueGetter: ({ value }) => {
               return ethers.BigNumber.from(value);
             },
-            valueFormatter: ({ value }) => {
-              return trimValue(ethers.utils.formatUnits(value));
-            },
+            renderCell: (params) => (
+              <TrimmedCell value={params.value || 0} />
+            ),
           },
         ]}
         initialState={{

--- a/web/src/components/TrimmedCell.js
+++ b/web/src/components/TrimmedCell.js
@@ -1,0 +1,19 @@
+
+import { ethers } from "ethers";
+
+export default function TrimmedCell({ value }) {
+  let valueFormatted = ethers.utils.commify(ethers.utils.formatUnits(value))
+  return (
+    <span
+      title={valueFormatted}
+      style={{
+        overflow: "hidden",
+        whiteSpace: "nowrap",
+        textOverflow: "ellipsis",
+        marginLeft: "2em",
+      }}
+    >
+      {valueFormatted}
+    </span>
+  );
+}

--- a/web/src/pages/NodePage.js
+++ b/web/src/pages/NodePage.js
@@ -7,7 +7,6 @@ import {
   BNSortComparator,
   rocketscanUrl,
   shortenAddress,
-  trimValue,
 } from "../utils";
 import { OpenInNew } from "@mui/icons-material";
 import { DataGrid } from "@mui/x-data-grid";
@@ -17,6 +16,7 @@ import { useState } from "react";
 import useFetchJSONZST from "../hooks/useFetchJSONZST";
 import { ethers } from "ethers";
 import { Link } from "react-router-dom";
+import TrimmedCell from "../components/TrimmedCell";
 
 // const IPFS_BASE = "https://ipfs.io";
 const IPFS_BASE = "https://cloudflare-ipfs.com";
@@ -94,9 +94,9 @@ const USER_COLS = [
         ethers.BigNumber.from(oracleDaoRpl)
       );
     },
-    valueFormatter: ({ value }) => {
-      return trimValue(ethers.utils.formatUnits(value));
-    },
+    renderCell: (params) => (
+      <TrimmedCell value={params.value || 0} />
+    ),
   },
   {
     field: "collateralRpl",
@@ -110,9 +110,9 @@ const USER_COLS = [
       }
       return ethers.BigNumber.from(value);
     },
-    valueFormatter: ({ value }) => {
-      return trimValue(ethers.utils.formatUnits(value));
-    },
+    renderCell: (params) => (
+      <TrimmedCell value={params.value || 0} />
+    ),
   },
   {
     field: "oracleDaoRpl",
@@ -126,9 +126,9 @@ const USER_COLS = [
       }
       return ethers.BigNumber.from(value);
     },
-    valueFormatter: ({ value }) => {
-      return trimValue(ethers.utils.formatUnits(value));
-    },
+    renderCell: (params) => (
+      <TrimmedCell value={params.value || 0} />
+    ),
   },
   {
     field: "smoothingPoolEth",
@@ -142,9 +142,9 @@ const USER_COLS = [
       }
       return ethers.BigNumber.from(value);
     },
-    valueFormatter: ({ value }) => {
-      return trimValue(ethers.utils.formatUnits(value));
-    },
+    renderCell: (params) => (
+      <TrimmedCell value={params.value || 0} />
+    ),
   },
 ];
 const USER_COL_WIDTH =

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -22,23 +22,6 @@ export function BNSortComparator(a, b) {
   return -1;
 }
 
-// convert "1234.123415123123123123" into "1,234.1234"
-export function trimValue(
-  amountEthish,
-  { maxDecimals = 4, maxLength = 11 } = {}
-) {
-  if (amountEthish.indexOf(".") !== -1) {
-    amountEthish = amountEthish.slice(
-      0,
-      amountEthish.indexOf(".") + maxDecimals + (maxDecimals ? 1 : 0)
-    );
-  }
-  if (amountEthish.length <= maxLength) {
-    return `${ethers.utils.commify(amountEthish)}`;
-  }
-  return `${ethers.utils.commify(amountEthish.substring(0, maxLength))}…`;
-}
-
 // Returns the sha1 of the provided array buffer asa hex string.
 export async function makeSha1Hash(buffer) {
   let hashBuffer = await crypto.subtle.digest("SHA-1", buffer);


### PR DESCRIPTION
## Problem
The current implementation of value trimming by modifying the string itself means that it's not possible to get the exact value of rewards using Rocketbread, despite the full data being available in the JSON trees.

## Solution
I've used a styled component which takes advantage of the CSS [text-overflow](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow) feature. By leaving the visual styling up to CSS we can retain the full precision of the reward values in the cell, while maintaining a similar visual display of the table.

This has the advantage that a user can select & copy the underlying full-precision value for use elsewhere.

### Screenshot
![image](https://github.com/dmccartney/rocketbread/assets/6219869/1b3dc871-0beb-48fd-8928-2d748905c3f3)
